### PR TITLE
Fixed popup/label overlap problem

### DIFF
--- a/dist/leaflet.label-src.js
+++ b/dist/leaflet.label-src.js
@@ -27,7 +27,7 @@ L.Label = L.Popup.extend({
 		if (animFade) {
 			L.DomUtil.setOpacity(this._container, 0);
 		}
-		map._panes.popupPane.appendChild(this._container);
+		map._panes.markerPane.appendChild(this._container);
 
 		map.on('viewreset', this._updatePosition, this);
 


### PR DESCRIPTION
Labels were attached to the popup pane, preventing popups form appearing above labels, despite a higher z-index. Changed to attach to the markerPane instead.
