### PR TITLE
Fix for Argument Error in Internet Explorer 9?

### DIFF
--- a/dist/leaflet.label-src.js
+++ b/dist/leaflet.label-src.js
@@ -82,7 +82,7 @@ L.Label = L.Popup.extend({
 	updateZIndex: function (zIndex) {
 		this._zIndex = zIndex;
 
-		if (this._container) {
+		if (this._container && zIndex !== undefined) {
 			this._container.style.zIndex = zIndex;
 		}
 	},


### PR DESCRIPTION
I encountered a SCRIPT87 error in leaflet.label-src.js, line 86, in Internet Explorer 9 (Windows Server 2003). I think the problem, which prevents the labels from rendering, is isolated to IE (as many are), but in the interest of supporting government and educational users relegated to that browser, I thought I should submit what appears to be a fix.

IE threw SCRIPT87 (Argument Error) because this._container.style.zIndex was being set to undefined (the value that zIndex took on at some point). Alternatively, zIndex could be set to an empty String anytime it is found to be undefined.

``` javascript
    updateZIndex: function (zIndex) {
        this._zIndex = zIndex;

        if (this._container && zIndex !== undefined) {
            this._container.style.zIndex = zIndex;
        }
    },
```
