### PR TITLE
allow open labels to be closed by tap on mobile.

### DIFF
--- a/src/Label.js
+++ b/src/Label.js
@@ -30,6 +30,10 @@ L.Label = L.Popup.extend({
 			map.on('zoomanim', this._zoomAnimation, this);
 		}
 
+		if (L.Browser.touch && !this.options.noHide) {
+			L.DomEvent.on(this._container, 'click', this.close, this);
+		}
+
 		this._update();
 
 		if (animFade) {
@@ -56,6 +60,9 @@ L.Label = L.Popup.extend({
 
 	close: function () {
 		var map = this._map;
+		if (L.Browser.touch && !this.options.noHide) {
+			L.DomEvent.off(this._container, 'click', this.close);
+		}
 
 		if (map) {
 			map._label = null;


### PR DESCRIPTION
On a mobile device, a map with a lot of labels open can get pretty cluttered. This allows you to close open labels by tapping them. It is only enabled if noHide is false.
