### PR TITLE
don't show labels for markers that have an opacity of 0.

### DIFF
--- a/example/label.html
+++ b/example/label.html
@@ -29,6 +29,9 @@
 			.addTo(map)
 			.showLabel();
 
+		var m = L.marker(map.getCenter(), {draggable:true,opacity:0}).bindLabel('A hidden label!', { noHide: true, watchOpacity:true })
+			.addTo(map);
+			
 		// Move marker to confirm that label moves when marker moves (first click)
 		// Remove marker on click so we can check that the label is also removed (second click)
 		var clicks = 0;

--- a/src/Label.js
+++ b/src/Label.js
@@ -4,7 +4,8 @@ L.Label = L.Popup.extend({
 		className: '',
 		closePopupOnClick: false,
 		noHide: false,
-		offset: new L.Point(12, -15) // 6 (width of the label triangle) + 6 (padding)
+		offset: new L.Point(12, -15), // 6 (width of the label triangle) + 6 (padding)
+		watchOpacity: false
 	},
 
 	onAdd: function (map) {

--- a/src/Map.Label.js
+++ b/src/Map.Label.js
@@ -1,5 +1,6 @@
 L.Map.include({
 	showLabel: function (label) {
+		if (label.options.watchOpacity && label._source instanceof L.Marker && label._source.options.opacity === 0) {return; }
 		this._label = label;
 
 		return this.addLayer(label);


### PR DESCRIPTION
People who may be using opacity to control visibility of their markers (referenced here https://github.com/Leaflet/Leaflet/issues/4) probably don't want any attached labels popping up for them during mouseover. This prevents that, with an option called watchOpacity.
