### PR TITLE
Dont remove event handlers for remove and move

### DIFF
--- a/src/Marker.Label.js
+++ b/src/Marker.Label.js
@@ -113,9 +113,7 @@ L.Marker.include({
 	_removeLabelRevealHandlers: function () {
 		this
 			.off('mouseover', this.showLabel, this)
-			.off('mouseout', this.hideLabel, this)
-			.off('remove', this.hideLabel, this)
-			.off('move', this._moveLabel, this);
+			.off('mouseout', this.hideLabel, this);
 
 		if (L.Browser.touch) {
 			this.off('click', this.showLabel, this);


### PR DESCRIPTION
Fixed a bug where after calling `setLabelNoHide(true)` and then trying to
move/remove a marker, the bound label would not be moved/removed.

`_removeLabelRevealHandlers` shouldn't remove the `move` and `remove` event handlers as they are not bound in `_addLabelRevealHandlers`.
