### PR TITLE
Static labels for L.CircleMarker objects

### DIFF
--- a/src/CircleMarker.Label.js
+++ b/src/CircleMarker.Label.js
@@ -21,12 +21,11 @@ L.CircleMarker.include({
         }
                            
         options = L.Util.extend({offset: anchor}, options);
-        this
-            ._label=new L.Label(options,this)
-            ._label.setContent(content)
-            ._showLabelAdded
-            ._showLabel
-            ._labelNoHide = options.noHide;
+        this._label=new L.Label(options,this);
+        this._label.setContent(content);
+        this._showLabelAdded;
+        this._showLabel;
+        this._labelNoHide = options.noHide;
                            
         if (!this._label) {
             if (!this._labelNoHide) {
@@ -41,18 +40,19 @@ L.CircleMarker.include({
         }
            
         if (!this._showLabelAdded) {
-             if (!this._labelNoHide) {
+                           
+            if (!this._labelNoHide && !options.mobile) {
                 this.on('mouseover', this._showLabel, this);
                 this.on('mousemove', this._moveLabel, this);           
                 this.on('mouseout remove', this._hideLabel, this);
-             }
+            }
                            
             if (L.Browser.touch) {
                 this.on('click', this._showLabel, this);
             }
                            
             this._showLabelAdded = true;
-        }                           
+        }                          
                            
         this._label = new L.Label(options, this)
         .setContent(content);

--- a/src/Label.js
+++ b/src/Label.js
@@ -83,8 +83,14 @@ L.Label = L.Popup.extend({
 	},
 
 	_initLayout: function () {
-		this._container = L.DomUtil.create('div', 'leaflet-label ' + this.options.className + ' leaflet-zoom-animated');
-		this.updateZIndex(this._zIndex);
+        if (this.options.labelClassName != null) {
+            var labelClass = this.options.labelClassName;
+        } else {    
+            var labelClass = "leaflet-label";
+        }
+       
+        this._container=L.DomUtil.create("div", labelClass + " " + this.options.className+" leaflet-zoom-animated"), 
+        this.updateZIndex(this._zIndex)
 	},
 
 	_updateContent: function () {


### PR DESCRIPTION
I added a function to override L.CircleMarker.include to allow static labels for CircleMarker objects.
I needed this for a project and I saw that there was an issue regarding this, Issue #31.  Since there seems to be some demand I am issuing a pull request on my update.
