### PR TITLE
Allow center-position of Labels

### DIFF
--- a/src/Label.js
+++ b/src/Label.js
@@ -156,14 +156,14 @@ L.Label = L.Class.extend({
 			offset = L.point(this.options.offset);
 
 		// Left, Center, Right positioning. 'Auto' chooses left or right as
-        // necessary to fit the label on the map.
-        if (direction === 'center') {
+		// necessary to fit the label on the map.
+		if (direction === 'center') {
 			L.DomUtil.addClass(container, 'leaflet-label-center');
 			L.DomUtil.removeClass(container, 'leaflet-label-left');
 			L.DomUtil.removeClass(container, 'leaflet-label-right');
 
 			pos = pos.add(L.point(-offset.x - (labelWidth / 2), offset.y));
-        } else if (direction === 'right' || direction === 'auto' && labelPoint.x < centerPoint.x) {
+		} else if (direction === 'right' || direction === 'auto' && labelPoint.x < centerPoint.x) {
 			L.DomUtil.addClass(container, 'leaflet-label-right');
 			L.DomUtil.removeClass(container, 'leaflet-label-left');
 			L.DomUtil.removeClass(container, 'leaflet-label-center');


### PR DESCRIPTION
This pull request adds a 'center' option for 'position' that shifts the Label half its width rather than all or none of it. This can be used to horizontally center a Label, e.g. by:

```
var mapCenter = map.getCenter();
var label = new L.Label({
    classname: 'heading',
    direction: 'center',
    offset: [0, 0]
});
label.setContent('My Heading');
label.setLatLng([51.6, mapCenter.lng]);
map.showLabel(label);
```

The vertical position is still up to the caller - Label only calculates its width, not its height.
