### PR TITLE
Fix label placement if page has been scrolled

### DIFF
--- a/src/BaseMarkerMethods.js
+++ b/src/BaseMarkerMethods.js
@@ -124,6 +124,12 @@ L.BaseMarkerMethods = {
 	},
 
 	_moveLabel: function (e) {
-		this.label.setLatLng(e.latlng);
+		// Translate label correctly if page has been scrolled
+		var map = this._map;
+		var point = map.latLngToLayerPoint(e.latlng);
+		var translateBy = L.point(window.pageXOffset, window.pageYOffset);
+		var translatedPoint = point.add(translateBy);
+		var newlatlng = map.layerPointToLatLng(translatedPoint);
+		this.label.setLatLng(newlatlng);
 	}
 };


### PR DESCRIPTION
I found that my polygon labels were being placed incorrectly if you scroll down the page. It seems like the latlng passed to _moveLabel was relative to the map's original placement on the page, not the new placement after scrolling the page. 

My solution is the use window.pageXOffset and pageYOffset to translate the label as necessary. Not sure if this is the best way to do it, but it works for me.
