### PR TITLE
Disable pointer-events for the label div

### DIFF
--- a/dist/leaflet.label.css
+++ b/dist/leaflet.label.css
@@ -17,6 +17,7 @@
 	   -moz-user-select: none;
 	    -ms-user-select: none;
 	        user-select: none;
+	pointer-events: none;
 	white-space: nowrap;
 	z-index: 6;
 }


### PR DESCRIPTION
Without this, a quickly-moving cursor can reach the label div before it is repositioned by Leaflet.label, where the div will intercept the hover events and disable the label. Once the label is gone, the hover event goes to the map below, causing a mouseover event and the label to show. Repeat a few dozen times per second and you get an annoying flicker:

![mapwithleafletlabelhoverflickerdemo](https://f.cloud.github.com/assets/261584/2129011/1f3284ee-9282-11e3-96d5-6e56ffd4747c.gif)

After the change:

![mapwithleafletlabelhoverflickerdemofixed](https://f.cloud.github.com/assets/261584/2129029/502da0ce-9282-11e3-981d-e9ea11876d2f.gif)
