### PR TITLE
Option to control which pane the label is added to

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ When you call ````bindLabel()```` you can pass in an options object. These optio
  - **noHide**: doesn't attach event handler for showing/hiding the label on mouseover/out.
  - **className**: the css class to add to the label element
  - **direction**: one of `left`|`right`(default)|`auto`. The direction the label displays in relation to the marker. `auto` will choose the optimal direction depending on the position of the marker.
+ - **pane**: which [map pane](http://leafletjs.com/reference.html#map-panes) to put the label into. By default, the `markerPane` will be used for markers, and the `popupPane` for other objects.
 
 E.g. To create a static label that automatically positions the label
 

--- a/src/Label.js
+++ b/src/Label.js
@@ -23,7 +23,8 @@ L.Label = L.Class.extend({
 	onAdd: function (map) {
 		this._map = map;
 
-		this._pane = this._source instanceof L.Marker ? map._panes.markerPane : map._panes.popupPane;
+		this._pane = this.options.pane ? map._panes[this.options.pane] :
+			this._source instanceof L.Marker ? map._panes.markerPane : map._panes.popupPane;
 
 		if (!this._container) {
 			this._initLayout();


### PR DESCRIPTION
To get a better control of which objects the label appears under or above, it is sometimes desirable to control which map pane the label is added to.

This PR adds to option `pane`, where you can specify where the label will be added. The default is the current behavior, `markerPane` for markers and `popupPane` for other objects.
