### PR TITLE
Add static label support to Paths

### DIFF
--- a/example/label.html
+++ b/example/label.html
@@ -51,8 +51,9 @@
 			[-37.7612, 175.2756],
 			[-37.7702, 175.2796],
 			[-37.7802, 175.2750]
-		],{ weight: 12, color: '#fe57a1' }).bindLabel('Even polylines can have labels.', { direction: 'auto' }).addTo(map);
+		],{ weight: 12, color: '#fe57a1' }).bindLabel('Even polylines can have static labels.', { direction: 'auto', noHide: true }).addTo(map);
 
+		p.showLabel();
 		// Remove polyline on click so we can check that the label is also removed
 		p.on('click', function () { map.removeLayer(p); });
 

--- a/src/Path.Label.js
+++ b/src/Path.Label.js
@@ -1,4 +1,20 @@
 L.Path.include({
+	showLabel: function () {
+		if (this.label && this._map) {
+			this.label.setLatLng(this.getBounds().getCenter());
+			this._map.showLabel(this.label);
+		}
+
+		return this;
+	},
+
+	hideLabel: function () {
+		if (this.label) {
+			this.label.close();
+		}
+		return this;
+	},
+
 	bindLabel: function (content, options) {
 		if (!this.label || this.label.options !== options) {
 			this.label = new L.Label(options, this);
@@ -6,15 +22,20 @@ L.Path.include({
 
 		this.label.setContent(content);
 
-		if (!this._showLabelAdded) {
-			this
-				.on('mouseover', this._showLabel, this)
-				.on('mousemove', this._moveLabel, this)
-				.on('mouseout remove', this._hideLabel, this);
+		this._labelNoHide = options && options.noHide;
 
-			if (L.Browser.touch) {
-				this.on('click', this._showLabel, this);
+		if (!this._showLabelAdded) {
+			if(!this._labelNoHide) {
+				this
+					.on('mouseover', this._showLabel, this)
+					.on('mousemove', this._moveLabel, this)
+					.on('mouseout', this._hideLabel, this);
+
+				if (L.Browser.touch) {
+					this.on('click', this._showLabel, this);
+				}
 			}
+			this.on('remove', this._hideLabel, this);
 			this._showLabelAdded = true;
 		}
 
@@ -26,10 +47,13 @@ L.Path.include({
 			this._hideLabel();
 			this.label = null;
 			this._showLabelAdded = false;
-			this
-				.off('mouseover', this._showLabel, this)
-				.off('mousemove', this._moveLabel, this)
-				.off('mouseout remove', this._hideLabel, this);
+			if(!this._labelNoHide) {
+				this
+					.off('mouseover', this._showLabel, this)
+					.off('mousemove', this._moveLabel, this)
+					.off('mouseout', this._hideLabel, this);
+			}
+			this.on('remove', this._hideLabel, this);
 		}
 		return this;
 	},


### PR DESCRIPTION
Static labels for paths use the calculated centriod as the label coordinate.remote

This will fix Leaflet/Leaflet.label#36 and does work for polylines etc, as they all descend from path.
