### PR TITLE
Updated to work with Leaflet 0.8-dev/ Leaflet 1.0

### DIFF
--- a/src/Label.js
+++ b/src/Label.js
@@ -1,4 +1,4 @@
-L.Label = L.Class.extend({
+L.Label = (L.Layer ? L.Layer : L.Class).extend({
 
 	includes: L.Mixin.Events,
 


### PR DESCRIPTION
Leaflet now uses Leaflet.Layer instead of Leaflet.Class, so adding this allows it to work with current Leaflet, and with future Leaflet.
