### PR TITLE
fix labels to accommodate new flyTo #129

### DIFF
--- a/src/Label.js
+++ b/src/Label.js
@@ -40,7 +40,8 @@ L.Label = (L.Layer ? L.Layer : L.Class).extend({
 
 		map
 			.on('moveend', this._onMoveEnd, this)
-			.on('viewreset', this._onViewReset, this);
+			.on('viewreset', this._onViewReset, this)
+			.on('zoomend', this._onZoomEnd,this);
 
 		if (this._animated) {
 			map.on('zoomanim', this._zoomAnimation, this);
@@ -184,6 +185,10 @@ L.Label = (L.Layer ? L.Layer : L.Class).extend({
 		if (!this._animated || this.options.direction === 'auto') {
 			this._updatePosition();
 		}
+	},
+	
+	_onZoomEnd: function () {
+			this._updatePosition();
 	},
 
 	_onViewReset: function (e) {


### PR DESCRIPTION
This fixes functionality when using the `flyTo()` method in Leaflet 1.0.1b. Only 

- movestart
- zoomstart
- move
- moveend
- zoomend

events are registered for the `flyTo()` method. This just updates the label on the zoomend event - I used this because there was already code in moveend. Not sure if this will regress any other functionality - I'm not sure how it's possible to tell whether the event was caused by `flyTo` or not.