### PR TITLE
Add support for HTML content.

### DIFF
--- a/src/Label.js
+++ b/src/Label.js
@@ -140,6 +140,12 @@ L.Label = (L.Layer ? L.Layer : L.Class).extend({
 			this._prevContent = this._content;
 
 			this._labelWidth = this._container.offsetWidth;
+		} else if (this._content instanceof Element) {
+			this._container.appendChild(this._content);
+
+			this._prevContent = this._content;
+
+			this._labelWidth = this._container.offsetWidth;
 		}
 	},
 


### PR DESCRIPTION
Add support for HTML content in a label just like the MarkerWithLabel extension for Google Maps.